### PR TITLE
Use shared ci-scripts

### DIFF
--- a/.ci-local/RELEASE
+++ b/.ci-local/RELEASE
@@ -1,0 +1,4 @@
+ASYN=/
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
+-include $(TOP)/configure/RELEASE.local

--- a/.ci-local/fix_RELEASE.sh
+++ b/.ci-local/fix_RELEASE.sh
@@ -1,0 +1,2 @@
+echo "Fixing RELEASE files"
+cp -f ${TRAVIS_BUILD_DIR}/.ci-local/RELEASE configure/

--- a/.ci-local/hooks.set
+++ b/.ci-local/hooks.set
@@ -1,0 +1,3 @@
+ASYN_HOOK=.ci-local/fix_RELEASE.sh
+CALC_HOOK=.ci-local/fix_RELEASE.sh
+MOTOR_HOOK=.ci-local/fix_RELEASE.sh

--- a/.ci-local/latest.set
+++ b/.ci-local/latest.set
@@ -1,0 +1,8 @@
+MODULES=asyn calc motor
+
+include motor
+include hooks
+
+ASYN=R4-38
+CALC=R3-7-3
+MOTOR=ess-master

--- a/.ci-local/motor.set
+++ b/.ci-local/motor.set
@@ -1,0 +1,4 @@
+# CI settings for the ESS Motor Record
+
+MOTOR_REPOOWNER=EuropeanSpallationSource
+MOTOR=ess-master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".ci"]
+	path = .ci
+	url = https://github.com/epics-base/ci-scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,89 @@
-sudo: false
-dist: bionic
-language: c
-compiler:
-  - gcc
+# .travis.yml for use with EPICS Base ci-scripts
+# (see: https://github.com/epics-base/ci-scripts)
+
+# This is YAML - indentation levels are crucial
+
+language: cpp
+compiler: gcc
+dist: xenial
+
 cache:
   directories:
-    - $HOME/.cache
+  - $HOME/.cache
+
+env:
+  global:
+    - SETUP_PATH=.ci-local:.ci
+
 addons:
   apt:
     packages:
+    # for all EPICS builds
     - libreadline6-dev
     - libncurses5-dev
     - perl
+    # for clang compiler
     - clang
+    # for mingw builds (32bit and 64bit)
     - g++-mingw-w64-i686
+    - g++-mingw-w64-x86-64
+    # for RTEMS cross builds
+    - qemu-system-x86
+  homebrew:
+    packages:
+    # for all EPICS builds
+    - bash
+    # for the sequencer
     - re2c
-env:
- - BASE=7.0     STATIC=shared                     ASYN=R4-35 MOTOR=v7.0.1-ESS
- - BASE=7.0     STATIC=static                     ASYN=R4-35 MOTOR=v7.0.1-ESS
-install: ./.ci-ethercatmc/travis-prepare.sh
-script: make
+    update: true
+
+install:
+  - ./.ci/travis/prepare.sh
+
+script:
+  - ./.ci/travis/build.sh
+
+# If you need to do more during install and build,
+# add a local directory to your module and do e.g.
+#  - ./.ci-local/travis/install-extras.sh
+
+# Define build jobs
+
+# Well-known variables to use
+# SET      source setup file
+# EXTRA    content will be added to make command line
+# STATIC   set to YES for static build (default: NO)
+# TEST     set to NO to skip running the tests (default: YES)
+# VV       set to make build scripts verbose (default: unset)
+
+# Usually from setup files, but may be specified or overridden
+#  on a job line
+# MODULES  list of dependency modules
+# BASE     branch or release tag name of the EPICS Base to use
+# <MODULE> branch or release tag for a specific module
+# ...      see README for setup file syntax description
+
+jobs:
+  include:
+
+# Different compilers: gcc and clang
+
+  - env: BASE=7.0 SET=latest
+
+  - env: BASE=7.0 SET=latest
+    compiler: clang
+
+  - env: BASE=7.0 SET=latest STATIC=YES
+
+  - env: BASE=R3.15.7 SET=latest
+
+# Trusty: compiler versions very close to RHEL 7
+
+  - env: BASE=7.0 SET=latest
+    dist: trusty
+
+# MacOS build
+
+  - env: BASE=7.0 SET=latest
+    os: osx
+    compiler: clang


### PR DESCRIPTION
Here's a simple first version of adding Travis-CI definitions using the shared ci-scripts module of EPICS Base.
See https://travis-ci.org/ralphlange/m-epics-EthercatMC for the related Travis build.