### PR TITLE
Update ci-scripts to v2.1.0

### DIFF
--- a/.ci-local/RELEASE
+++ b/.ci-local/RELEASE
@@ -1,4 +1,0 @@
-ASYN=/
--include $(TOP)/../RELEASE.local
--include $(TOP)/../RELEASE.$(EPICS_HOST_ARCH).local
--include $(TOP)/configure/RELEASE.local

--- a/.ci-local/fix_RELEASE.sh
+++ b/.ci-local/fix_RELEASE.sh
@@ -1,2 +1,0 @@
-echo "Fixing RELEASE files"
-cp -f ${TRAVIS_BUILD_DIR}/.ci-local/RELEASE configure/

--- a/.ci-local/hooks.set
+++ b/.ci-local/hooks.set
@@ -1,3 +1,0 @@
-ASYN_HOOK=.ci-local/fix_RELEASE.sh
-CALC_HOOK=.ci-local/fix_RELEASE.sh
-MOTOR_HOOK=.ci-local/fix_RELEASE.sh

--- a/.ci-local/latest.set
+++ b/.ci-local/latest.set
@@ -1,7 +1,6 @@
 MODULES=asyn calc motor
 
 include motor
-include hooks
 
 ASYN=R4-38
 CALC=R3-7-3


### PR DESCRIPTION
Update to ci-scripts v2.1.0, which allows to drop all HOOK scripts.